### PR TITLE
Add plotting utility for Abaqus report files

### DIFF
--- a/empty.m
+++ b/empty.m
@@ -1,0 +1,199 @@
+function plot_reports_matlab(dataDir, outputDir)
+if nargin < 1 || isempty(dataDir)
+    dataDir = 'data_report';
+end
+if nargin < 2 || isempty(outputDir)
+    outputDir = 'figures_matlab';
+end
+reports = dir(fullfile(dataDir, '*.rpt'));
+if isempty(reports)
+    error('No .rpt files found in %s', dataDir);
+end
+if ~exist(outputDir, 'dir')
+    mkdir(outputDir);
+end
+[engFont, chiFont] = resolve_fonts();
+default_label_x = mixed_font_text('位移/mm', engFont, chiFont);
+default_label_y = mixed_font_text('荷载/kN', engFont, chiFont);
+allSeries = cell(1, numel(reports));
+for k = 1:numel(reports)
+    series = load_report(fullfile(dataDir, reports(k).name));
+    allSeries{k} = series;
+    fig = figure('Visible', 'off', 'Units', 'centimeters');
+    fig.Position(3:4) = [8 6];
+    ax = axes('Parent', fig);
+    hold(ax, 'on');
+    plot(ax, series.x, series.y, 'LineWidth', 1.0, 'Marker', 'o', 'MarkerSize', 2.0, ...
+        'MarkerFaceColor', 'none', 'MarkerEdgeColor', ax.ColorOrder(1,:), 'MarkerEdgeWidth', 0.8);
+    xlabel(ax, default_label_x, 'Interpreter', 'tex');
+    ylabel(ax, default_label_y, 'Interpreter', 'tex');
+    title(ax, mixed_font_text(series.title, engFont, chiFont), 'Interpreter', 'tex', 'FontSize', 10);
+    grid(ax, 'on');
+    ax.GridLineStyle = '--';
+    ax.GridAlpha = 0.5;
+    ax.LineWidth = 0.4;
+    ax.FontName = engFont;
+    legend(ax, mixed_font_text(series.title, engFont, chiFont), 'Location', 'best', ...
+        'Interpreter', 'tex', 'Box', 'off');
+    print(fig, fullfile(outputDir, [series.safeName '.svg']), '-dsvg');
+    close(fig);
+end
+grouped = group_series(allSeries);
+keys = string(fieldnames(grouped));
+for i = 1:numel(keys)
+    key = keys(i);
+    groupSeries = grouped.(key);
+    if numel(groupSeries) < 2
+        continue;
+    end
+    plot_group(groupSeries, fullfile(outputDir, ['comparison_' char(key) '.svg']), ...
+        engFont, chiFont, default_label_x, default_label_y, char(key));
+end
+if numel(allSeries) > 1
+    plot_group(allSeries, fullfile(outputDir, 'comparison_all.svg'), engFont, chiFont, ...
+        default_label_x, default_label_y, 'All Series Comparison');
+end
+end
+
+function series = load_report(path)
+fid = fopen(path, 'r');
+if fid == -1
+    error('Cannot open %s', path);
+end
+cleanup = onCleanup(@() fclose(fid));
+rawX = [];
+rawY = [];
+header = {};
+while true
+    line = fgetl(fid);
+    if ~ischar(line)
+        break;
+    end
+    line = strtrim(line);
+    if isempty(line)
+        continue;
+    end
+    tokens = strsplit(line);
+    if is_data_line(tokens)
+        rawX(end+1) = str2double(tokens{1}); %#ok<AGROW>
+        rawY(end+1) = str2double(tokens{2}) * 1e-3; %#ok<AGROW>
+    else
+        header{end+1} = line; %#ok<AGROW>
+    end
+end
+if isempty(header)
+    header = {};
+end
+[~, baseName, ~] = fileparts(path);
+series.name = baseName;
+if isempty(header)
+    series.title = baseName;
+else
+    series.title = header{1};
+end
+series.safeName = regexprep(baseName, '\s+', '_');
+series.x = rawX;
+series.y = rawY;
+end
+
+function tf = is_data_line(tokens)
+if numel(tokens) < 2
+    tf = false;
+    return;
+end
+x = str2double(tokens{1});
+y = str2double(tokens{2});
+tf = ~(isnan(x) || isnan(y));
+end
+
+function grouped = group_series(seriesCell)
+keys = strings(1, numel(seriesCell));
+for i = 1:numel(seriesCell)
+    name = string(seriesCell{i}.safeName);
+    dash = strfind(name, '-');
+    if isempty(dash)
+        keys(i) = name;
+    else
+        keys(i) = extractBefore(name, dash(1));
+    end
+end
+uniqueKeys = unique(keys);
+for k = 1:numel(uniqueKeys)
+    idx = keys == uniqueKeys(k);
+    grouped.(uniqueKeys(k)) = seriesCell(idx);
+end
+end
+
+function plot_group(seriesCell, outPath, engFont, chiFont, xlabelText, ylabelText, key)
+fig = figure('Visible', 'off', 'Units', 'centimeters');
+fig.Position(3:4) = [8 6];
+ax = axes('Parent', fig);
+hold(ax, 'on');
+for i = 1:numel(seriesCell)
+    series = seriesCell{i};
+    weight = 1.0;
+    if contains(lower(series.safeName), 'base')
+        weight = 1.4;
+    end
+    plot(ax, series.x, series.y, 'DisplayName', mixed_font_text(series.title, engFont, chiFont), ...
+        'LineWidth', weight, 'Marker', 'o', 'MarkerSize', 2.0, 'MarkerFaceColor', 'none', ...
+        'MarkerEdgeWidth', 0.8);
+end
+xlabel(ax, xlabelText, 'Interpreter', 'tex');
+ylabel(ax, ylabelText, 'Interpreter', 'tex');
+title(ax, mixed_font_text(sprintf('Comparison – %s', key), engFont, chiFont), ...
+    'Interpreter', 'tex', 'FontSize', 10);
+grid(ax, 'on');
+ax.GridLineStyle = '--';
+ax.GridAlpha = 0.5;
+ax.LineWidth = 0.4;
+ax.FontName = engFont;
+leg = legend(ax, 'show', 'Location', 'best', 'Interpreter', 'tex', 'Box', 'off'); %#ok<NASGU>
+print(fig, outPath, '-dsvg');
+close(fig);
+end
+
+function [engFont, chiFont] = resolve_fonts()
+fonts = listfonts;
+engFont = 'Times New Roman';
+if ~any(strcmpi(fonts, engFont))
+    engFont = fonts{1};
+end
+chiFont = 'SimSun';
+if ~any(strcmpi(fonts, chiFont))
+    chiFont = engFont;
+end
+end
+
+function out = mixed_font_text(text, engFont, chiFont)
+chars = char(text);
+segments = strings(1, 0);
+currentFont = '';
+currentSegment = "";
+for i = 1:numel(chars)
+    ch = chars(i);
+    if is_chinese_char(ch)
+        fontName = chiFont;
+    else
+        fontName = engFont;
+    end
+    if ~strcmp(fontName, currentFont)
+        if strlength(currentSegment) > 0
+            segments(end+1) = currentSegment; %#ok<AGROW>
+        end
+        currentSegment = "\fontname{" + fontName + "}" + string(ch);
+        currentFont = fontName;
+    else
+        currentSegment = currentSegment + string(ch);
+    end
+end
+if strlength(currentSegment) > 0
+    segments(end+1) = currentSegment;
+end
+out = char(strjoin(segments, ''));
+end
+
+function tf = is_chinese_char(ch)
+code = double(ch);
+tf = code >= hex2dec('4E00') && code <= hex2dec('9FFF');
+end

--- a/plot_reports.py
+++ b/plot_reports.py
@@ -27,6 +27,11 @@ from matplotlib import font_manager
 from matplotlib.font_manager import FontProperties
 
 
+CHINESE_LABEL = "位移/mm"
+FORCE_LABEL = "荷载/kN"
+FORCE_SCALE = 1e-3
+
+
 CM_TO_INCH = 1 / 2.54
 FIGURE_SIZE = (8 * CM_TO_INCH, 6 * CM_TO_INCH)
 
@@ -63,7 +68,7 @@ def discover_font(family: str) -> FontProperties | None:
     return FontProperties(fname=font_path)
 
 
-def configure_fonts() -> tuple[FontProperties, FontProperties]:
+def configure_fonts() -> tuple[FontProperties, FontProperties, FontProperties]:
     """Configure Matplotlib defaults and return font properties.
 
     The function attempts to use SimSun for Chinese text and Times New Roman
@@ -98,7 +103,13 @@ def configure_fonts() -> tuple[FontProperties, FontProperties]:
                 *current_sans,
             ]
 
-    return english_font, chinese_font
+    combined_font = FontProperties()
+    families = [english_font.get_name()]
+    if chinese_font.get_name() not in families:
+        families.append(chinese_font.get_name())
+    combined_font.set_family(families)
+
+    return english_font, chinese_font, combined_font
 
 
 def is_data_line(tokens: List[str]) -> bool:
@@ -131,7 +142,7 @@ def load_report(path: Path) -> ReportSeries:
             tokens = line.split()
             if is_data_line(tokens):
                 x_values.append(float(tokens[0]))
-                y_values.append(float(tokens[1]))
+                y_values.append(float(tokens[1]) * FORCE_SCALE)
             else:
                 header.append(line)
                 if len(tokens) >= 2:
@@ -143,24 +154,60 @@ def load_report(path: Path) -> ReportSeries:
     return ReportSeries(name=name, x=x_values, y=y_values, x_label=x_label, y_label=y_label, title=title)
 
 
-def plot_series(series: ReportSeries, output_dir: Path, fonts: tuple[FontProperties, FontProperties]) -> None:
+def contains_chinese(text: str) -> bool:
+    """Return ``True`` when the string contains any Chinese characters."""
+
+    return any("\u4e00" <= char <= "\u9fff" for char in text)
+
+
+def choose_font(
+    english_font: FontProperties, chinese_font: FontProperties, combined_font: FontProperties, text: str
+) -> FontProperties:
+    """Return the appropriate font for the supplied text."""
+
+    if not contains_chinese(text):
+        return english_font
+    if english_font.get_name() == chinese_font.get_name():
+        return english_font
+    return combined_font
+
+
+def plot_series(
+    series: ReportSeries,
+    output_dir: Path,
+    fonts: tuple[FontProperties, FontProperties, FontProperties],
+) -> None:
     """Create an individual plot for a single data series."""
 
-    english_font, chinese_font = fonts
+    english_font, chinese_font, combined_font = fonts
     fig, ax = plt.subplots(figsize=FIGURE_SIZE)
-    ax.plot(series.x, series.y, linewidth=1.2, marker="o", markersize=2.4, label=series.title)
-    ax.set_xlabel(series.x_label, fontproperties=english_font)
-    ax.set_ylabel(series.y_label, fontproperties=english_font)
-    ax.set_title(series.title, fontproperties=english_font, fontsize=10)
+    ax.plot(
+        series.x,
+        series.y,
+        linewidth=1.0,
+        marker="o",
+        markersize=2.0,
+        markerfacecolor="none",
+        markeredgewidth=0.8,
+        label=series.title,
+    )
+    ax.set_xlabel(CHINESE_LABEL, fontproperties=combined_font)
+    ax.set_ylabel(FORCE_LABEL, fontproperties=combined_font)
+    title_text = ax.set_title(series.title, fontsize=10)
+    title_text.set_fontproperties(
+        choose_font(english_font, chinese_font, combined_font, title_text.get_text())
+    )
     ax.grid(True, linewidth=0.4, linestyle="--", alpha=0.5)
 
     for label in ax.get_xticklabels() + ax.get_yticklabels():
         label.set_fontproperties(english_font)
 
-    legend = ax.legend(loc="best", frameon=False, prop=english_font)
+    legend = ax.legend(loc="best", frameon=False)
     if legend is not None:
         for text in legend.get_texts():
-            text.set_fontproperties(chinese_font)
+            text.set_fontproperties(
+                choose_font(english_font, chinese_font, combined_font, text.get_text())
+            )
 
     fig.tight_layout()
     output_path = output_dir / f"{series.safe_name}.svg"
@@ -171,28 +218,41 @@ def plot_series(series: ReportSeries, output_dir: Path, fonts: tuple[FontPropert
 def plot_group(
     series_list: Iterable[ReportSeries],
     output_path: Path,
-    fonts: tuple[FontProperties, FontProperties],
+    fonts: tuple[FontProperties, FontProperties, FontProperties],
     title: str,
 ) -> None:
     """Plot multiple series together for comparison."""
 
-    english_font, chinese_font = fonts
+    english_font, chinese_font, combined_font = fonts
     fig, ax = plt.subplots(figsize=FIGURE_SIZE)
 
     for series in series_list:
         linewidth = 1.4 if "base" in series.name.lower() else 1.0
-        ax.plot(series.x, series.y, label=series.name, linewidth=linewidth)
+        ax.plot(
+            series.x,
+            series.y,
+            label=series.name,
+            linewidth=linewidth,
+            marker="o",
+            markersize=2.0,
+            markerfacecolor="none",
+            markeredgewidth=0.8,
+        )
 
-    reference_series = next(iter(series_list))
-    ax.set_xlabel(reference_series.x_label, fontproperties=english_font)
-    ax.set_ylabel(reference_series.y_label, fontproperties=english_font)
-    ax.set_title(title, fontproperties=english_font, fontsize=10)
+    ax.set_xlabel(CHINESE_LABEL, fontproperties=combined_font)
+    ax.set_ylabel(FORCE_LABEL, fontproperties=combined_font)
+    title_text = ax.set_title(title, fontsize=10)
+    title_text.set_fontproperties(
+        choose_font(english_font, chinese_font, combined_font, title_text.get_text())
+    )
     ax.grid(True, linewidth=0.4, linestyle="--", alpha=0.5)
 
     legend = ax.legend(loc="best", frameon=False)
     if legend is not None:
         for text in legend.get_texts():
-            text.set_fontproperties(chinese_font)
+            text.set_fontproperties(
+                choose_font(english_font, chinese_font, combined_font, text.get_text())
+            )
 
     for label in ax.get_xticklabels() + ax.get_yticklabels():
         label.set_fontproperties(english_font)

--- a/plot_reports.py
+++ b/plot_reports.py
@@ -1,0 +1,271 @@
+"""Utility for visualising Abaqus report files.
+
+The script discovers ``.rpt`` files in a data directory, parses the
+tabulated output and generates individual as well as comparative plots.
+Figures follow the styling requested by the user:
+
+* Figure size: 8 cm × 6 cm (converted to inches for Matplotlib).
+* Fonts: Times New Roman for latin characters and SimSun for Chinese.
+* Output format: SVG.
+
+Run the script from the repository root, for example::
+
+    python plot_reports.py --data-dir data_report --output-dir figures
+
+The resulting SVG figures are written to ``figures/`` by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import matplotlib.pyplot as plt
+from matplotlib import font_manager
+from matplotlib.font_manager import FontProperties
+
+
+CM_TO_INCH = 1 / 2.54
+FIGURE_SIZE = (8 * CM_TO_INCH, 6 * CM_TO_INCH)
+
+
+@dataclass
+class ReportSeries:
+    """Container holding the numeric data extracted from a report."""
+
+    name: str
+    x: List[float]
+    y: List[float]
+    x_label: str
+    y_label: str
+    title: str
+
+    @property
+    def safe_name(self) -> str:
+        """Return a filesystem friendly name for the series."""
+
+        return self.name.replace(" ", "_")
+
+
+def discover_font(family: str) -> FontProperties | None:
+    """Return font properties if the requested family exists.
+
+    If the font cannot be found, ``None`` is returned so that callers can fall
+    back to a default font.
+    """
+
+    try:
+        font_path = font_manager.findfont(family, fallback_to_default=False)
+    except (ValueError, RuntimeError):
+        return None
+    return FontProperties(fname=font_path)
+
+
+def configure_fonts() -> tuple[FontProperties, FontProperties]:
+    """Configure Matplotlib defaults and return font properties.
+
+    The function attempts to use SimSun for Chinese text and Times New Roman
+    for latin characters.  When SimSun is unavailable on the system the
+    function keeps Times New Roman for all text while printing an informative
+    message.
+    """
+
+    english_font = discover_font("Times New Roman")
+    if english_font is None:
+        # Fall back to Matplotlib's default font but keep the style consistent.
+        english_font = FontProperties()
+
+    chinese_font = discover_font("SimSun")
+    if chinese_font is None:
+        print(
+            "[plot_reports] SimSun font not found on this system. "
+            "Falling back to Times New Roman for all text."
+        )
+        chinese_font = english_font
+
+    plt.rcParams["font.family"] = english_font.get_name()
+    plt.rcParams["axes.unicode_minus"] = False
+
+    # Register SimSun as a fallback font when it is present.
+    if chinese_font is not english_font:
+        plt.rcParams.setdefault("font.sans-serif", [])
+        current_sans = list(plt.rcParams["font.sans-serif"])
+        if chinese_font.get_name() not in current_sans:
+            plt.rcParams["font.sans-serif"] = [
+                chinese_font.get_name(),
+                *current_sans,
+            ]
+
+    return english_font, chinese_font
+
+
+def is_data_line(tokens: List[str]) -> bool:
+    """Return ``True`` if the tokens represent numeric data."""
+
+    if len(tokens) < 2:
+        return False
+    try:
+        for value in tokens[:2]:
+            float(value)
+    except ValueError:
+        return False
+    return True
+
+
+def load_report(path: Path) -> ReportSeries:
+    """Parse a two-column Abaqus ``.rpt`` file into a :class:`ReportSeries`."""
+
+    header: List[str] = []
+    x_values: List[float] = []
+    y_values: List[float] = []
+    x_label = "X"
+    y_label = "Y"
+
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            tokens = line.split()
+            if is_data_line(tokens):
+                x_values.append(float(tokens[0]))
+                y_values.append(float(tokens[1]))
+            else:
+                header.append(line)
+                if len(tokens) >= 2:
+                    x_label = tokens[0]
+                    y_label = tokens[1]
+
+    title = header[0] if header else path.stem
+    name = path.stem
+    return ReportSeries(name=name, x=x_values, y=y_values, x_label=x_label, y_label=y_label, title=title)
+
+
+def plot_series(series: ReportSeries, output_dir: Path, fonts: tuple[FontProperties, FontProperties]) -> None:
+    """Create an individual plot for a single data series."""
+
+    english_font, chinese_font = fonts
+    fig, ax = plt.subplots(figsize=FIGURE_SIZE)
+    ax.plot(series.x, series.y, linewidth=1.2, marker="o", markersize=2.4, label=series.title)
+    ax.set_xlabel(series.x_label, fontproperties=english_font)
+    ax.set_ylabel(series.y_label, fontproperties=english_font)
+    ax.set_title(series.title, fontproperties=english_font, fontsize=10)
+    ax.grid(True, linewidth=0.4, linestyle="--", alpha=0.5)
+
+    for label in ax.get_xticklabels() + ax.get_yticklabels():
+        label.set_fontproperties(english_font)
+
+    legend = ax.legend(loc="best", frameon=False, prop=english_font)
+    if legend is not None:
+        for text in legend.get_texts():
+            text.set_fontproperties(chinese_font)
+
+    fig.tight_layout()
+    output_path = output_dir / f"{series.safe_name}.svg"
+    fig.savefig(output_path, format="svg")
+    plt.close(fig)
+
+
+def plot_group(
+    series_list: Iterable[ReportSeries],
+    output_path: Path,
+    fonts: tuple[FontProperties, FontProperties],
+    title: str,
+) -> None:
+    """Plot multiple series together for comparison."""
+
+    english_font, chinese_font = fonts
+    fig, ax = plt.subplots(figsize=FIGURE_SIZE)
+
+    for series in series_list:
+        linewidth = 1.4 if "base" in series.name.lower() else 1.0
+        ax.plot(series.x, series.y, label=series.name, linewidth=linewidth)
+
+    reference_series = next(iter(series_list))
+    ax.set_xlabel(reference_series.x_label, fontproperties=english_font)
+    ax.set_ylabel(reference_series.y_label, fontproperties=english_font)
+    ax.set_title(title, fontproperties=english_font, fontsize=10)
+    ax.grid(True, linewidth=0.4, linestyle="--", alpha=0.5)
+
+    legend = ax.legend(loc="best", frameon=False)
+    if legend is not None:
+        for text in legend.get_texts():
+            text.set_fontproperties(chinese_font)
+
+    for label in ax.get_xticklabels() + ax.get_yticklabels():
+        label.set_fontproperties(english_font)
+
+    fig.tight_layout()
+    fig.savefig(output_path, format="svg")
+    plt.close(fig)
+
+
+def collect_series(data_dir: Path) -> List[ReportSeries]:
+    """Load all ``.rpt`` files from ``data_dir``."""
+
+    series_collection: List[ReportSeries] = []
+    for path in sorted(data_dir.glob("*.rpt")):
+        series_collection.append(load_report(path))
+    if not series_collection:
+        raise FileNotFoundError(f"No .rpt files found in {data_dir}")
+    return series_collection
+
+
+def group_series(series_collection: Iterable[ReportSeries]) -> dict[str, List[ReportSeries]]:
+    """Group report series using the file name prefix before the first dash."""
+
+    grouped: dict[str, List[ReportSeries]] = {}
+    for series in series_collection:
+        group_key = series.name.split("-")[0]
+        grouped.setdefault(group_key, []).append(series)
+    return grouped
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Plot Abaqus .rpt files as SVG figures.")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data_report"),
+        help="Directory that contains the .rpt files (default: data_report)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("figures"),
+        help="Directory where SVG figures are written (default: figures)",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    data_dir: Path = args.data_dir
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    fonts = configure_fonts()
+
+    series_collection = collect_series(data_dir)
+    for series in series_collection:
+        plot_series(series, output_dir, fonts)
+
+    group_map = group_series(series_collection)
+    for group_name, group_series_list in group_map.items():
+        if len(group_series_list) <= 1:
+            continue
+        output_path = output_dir / f"comparison_{group_name}.svg"
+        title = f"Comparison – {group_name}"
+        plot_group(group_series_list, output_path, fonts, title)
+
+    if len(series_collection) > 1:
+        output_path = output_dir / "comparison_all.svg"
+        plot_group(series_collection, output_path, fonts, "All Series Comparison")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib


### PR DESCRIPTION
## Summary
- add a Python script that parses Abaqus `.rpt` tables and produces SVG figures with the requested styling
- group datasets automatically to create comparison plots alongside individual series outputs
- document the matplotlib dependency for generating the charts

## Testing
- not run (matplotlib is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de80f4d72c8331ad98be967cf8500b